### PR TITLE
feat(auth): IDE extension redirect flow with Firebase token handoff and URL scheme validation

### DIFF
--- a/apps/contributor/tsconfig.json
+++ b/apps/contributor/tsconfig.json
@@ -22,6 +22,6 @@
       "@/*": ["./*"]
     }
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts", "../../packages/shared/models/horizon.model.ts"],
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
   "exclude": ["node_modules", ".next"]
 }

--- a/apps/project-maintainer/app/(pages)/(main)/installation/page.tsx
+++ b/apps/project-maintainer/app/(pages)/(main)/installation/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 import { auth, getCurrentUser, useUnauthenticatedUserCheck } from "@/lib/firebase";
-import { ROUTES } from "@/app/utils/data";
+import { ALLOWED_IDES, ROUTES } from "@/app/utils/data";
 import { useAsyncEffect, useLockFn } from "ahooks";
 import { InstallationAPI } from "@/app/services/installation.service";
 import useInstallationStore from "@/app/state-management/useInstallationStore";
@@ -53,6 +53,12 @@ const Installation = () => {
         try {
             const extAuth = JSON.parse(extensionAuthStr);
 
+            // Allowlist of supported IDE URL schemes to prevent arbitrary-scheme injection.
+            if (typeof extAuth?.ide !== "string" || !ALLOWED_IDES.includes(extAuth.ide)) {
+                localStorage.removeItem("extensionAuth");
+                return false;
+            }
+
             const refreshToken = auth.currentUser?.refreshToken;
             if (!refreshToken) {
                 return false;
@@ -70,8 +76,7 @@ const Installation = () => {
     };
 
     /**
-     * 
-     * @returns 
+     * Save installation data to database
      */
     const saveInstallation = async () => {
         setIsProcessing(true);

--- a/apps/project-maintainer/app/(pages)/(main)/installation/page.tsx
+++ b/apps/project-maintainer/app/(pages)/(main)/installation/page.tsx
@@ -11,6 +11,7 @@ import ButtonPrimary from "@devasign/shared/components/ButtonPrimary";
 import { MdOutlineCancel } from "react-icons/md";
 import { handleApiErrorResponse, handleApiSuccessResponse } from "@/app/utils/helper";
 import { useCustomSearchParams } from "@devasign/shared/hooks";
+import useUserStore from "@/app/state-management/useUserStore";
 
 /**
  * GitHub App installation callback page.
@@ -29,12 +30,12 @@ import { useCustomSearchParams } from "@devasign/shared/hooks";
 type ReboundAction = "INSTALL" | "RETRY" | "";
 
 const Installation = () => {
+    const { currentUser } = useUserStore();
     const router = useUnauthenticatedUserCheck();;
     const { searchParams } = useCustomSearchParams();
     const installationId = searchParams.get("installation_id");
     const [isProcessing, setIsProcessing] = useState(true);
     const [reboundAction, setReboundAction] = useState<ReboundAction>("");
-
     const {
         activeInstallation,
         installationList,
@@ -42,6 +43,47 @@ const Installation = () => {
         setInstallationList
     } = useInstallationStore();
 
+    /**
+     * Handles the redirect to the extension after installation.
+     */
+    const handleExtensionRedirect = async () => {
+        const extensionAuthStr = localStorage.getItem("extensionAuth");
+        if (extensionAuthStr) {
+            try {
+                const extAuth = JSON.parse(extensionAuthStr);
+                const installationsRes = await InstallationAPI.getInstallations({ getRepositories: "true" });
+                const installations = installationsRes.data;
+                
+                // Done to avoid hitting the URL maximum length limit
+                const minimalUser = {
+                    i: currentUser?.userId,
+                    u: currentUser?.username,
+                    e: currentUser?.email
+                };
+                const minimalInstallations = installations.map((inst) => ({
+                    i: inst.id,
+                    r: (inst.repositories || []).map((repo) => repo.name)
+                }));
+
+                const encodedUser = encodeURIComponent(JSON.stringify(minimalUser));
+                const encodedInstallations = encodeURIComponent(JSON.stringify(minimalInstallations));
+                const ideLink = `${extAuth.ide}://devasign.devasign/auth?user=${encodedUser}&installations=${encodedInstallations}`;
+                
+                localStorage.removeItem("extensionAuth");
+                localStorage.setItem("ideLink", ideLink);
+                router.push(ROUTES.EXTENSION_SUCCESS);
+                return true;
+            } catch {
+                return false;
+            }
+        }
+        return false;
+    };
+
+    /**
+     * 
+     * @returns 
+     */
     const saveInstallation = async () => {
         setIsProcessing(true);
         const user = await getCurrentUser();
@@ -63,6 +105,12 @@ const Installation = () => {
         if (existingInstallation) {
             setActiveInstallation(existingInstallation);
             toast.info("Installation already exists.");
+            
+            // If the user arrived from the extension, construct a deep link to return them
+            // to their IDE with their updated authentication and installation data.
+            const redirected = await handleExtensionRedirect();
+            if (redirected) return;
+
             router.push(ROUTES.TASKS);
             return;
         }
@@ -77,6 +125,11 @@ const Installation = () => {
             setActiveInstallation(response.data);
             setInstallationList([...installationList, response.data]);
             handleApiSuccessResponse(response);
+
+            // If the user arrived from the extension, construct a deep link to return them
+            // to their IDE with their updated authentication and installation data.
+            const redirected = await handleExtensionRedirect();
+            if (redirected) return;
 
             if (noCurrentInstallations) {
                 router.push(ROUTES.ONBOARDING);
@@ -97,7 +150,7 @@ const Installation = () => {
     useAsyncEffect(useLockFn(() => saveInstallation()), [router, installationId]);
 
     return (isProcessing || reboundAction === "") ? (
-        <div className="fixed inset-0 z-[100] bg-[#0000004D] grid place-content-center backdrop-blur-[14px] pointer-events-none">
+        <div className="fixed inset-0 z-100 bg-[#0000004D] grid place-content-center backdrop-blur-[14px] pointer-events-none">
             <div className="w-[820px] max-h-[92dvh] p-10 popup-modal relative bg-dark-500 pointer-events-auto">
                 <TbProgress className="text-[44px] text-primary-400 mx-auto rotate-loading-slower" />
                 <h2 className="text-headline-medium text-light-100 my-2.5 text-center">Saving Installation</h2>
@@ -107,7 +160,7 @@ const Installation = () => {
             </div>
         </div>
     ) : (
-        <div className="fixed inset-0 z-[100] bg-[#0000004D] grid place-content-center backdrop-blur-[14px] pointer-events-none">
+        <div className="fixed inset-0 z-100 bg-[#0000004D] grid place-content-center backdrop-blur-[14px] pointer-events-none">
             <div className="w-[820px] max-h-[92dvh] p-10 popup-modal relative bg-dark-500 pointer-events-auto">
                 <MdOutlineCancel className="text-[44px] text-indicator-500 mx-auto" />
                 <h2 className="text-headline-medium text-light-100 my-2.5 text-center">Process Failed</h2>

--- a/apps/project-maintainer/app/(pages)/(main)/installation/page.tsx
+++ b/apps/project-maintainer/app/(pages)/(main)/installation/page.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { getCurrentUser, useUnauthenticatedUserCheck } from "@/lib/firebase";
+import { auth, getCurrentUser, useUnauthenticatedUserCheck } from "@/lib/firebase";
 import { ROUTES } from "@/app/utils/data";
 import { useAsyncEffect, useLockFn } from "ahooks";
 import { InstallationAPI } from "@/app/services/installation.service";
@@ -11,7 +11,6 @@ import ButtonPrimary from "@devasign/shared/components/ButtonPrimary";
 import { MdOutlineCancel } from "react-icons/md";
 import { handleApiErrorResponse, handleApiSuccessResponse } from "@/app/utils/helper";
 import { useCustomSearchParams } from "@devasign/shared/hooks";
-import useUserStore from "@/app/state-management/useUserStore";
 
 /**
  * GitHub App installation callback page.
@@ -30,8 +29,7 @@ import useUserStore from "@/app/state-management/useUserStore";
 type ReboundAction = "INSTALL" | "RETRY" | "";
 
 const Installation = () => {
-    const { currentUser } = useUserStore();
-    const router = useUnauthenticatedUserCheck();;
+    const router = useUnauthenticatedUserCheck();
     const { searchParams } = useCustomSearchParams();
     const installationId = searchParams.get("installation_id");
     const [isProcessing, setIsProcessing] = useState(true);
@@ -48,36 +46,27 @@ const Installation = () => {
      */
     const handleExtensionRedirect = async () => {
         const extensionAuthStr = localStorage.getItem("extensionAuth");
-        if (extensionAuthStr) {
-            try {
-                const extAuth = JSON.parse(extensionAuthStr);
-                const installationsRes = await InstallationAPI.getInstallations({ getRepositories: "true" });
-                const installations = installationsRes.data;
-                
-                // Done to avoid hitting the URL maximum length limit
-                const minimalUser = {
-                    i: currentUser?.userId,
-                    u: currentUser?.username,
-                    e: currentUser?.email
-                };
-                const minimalInstallations = installations.map((inst) => ({
-                    i: inst.id,
-                    r: (inst.repositories || []).map((repo) => repo.name)
-                }));
+        if (!extensionAuthStr) {
+            return false;
+        }
 
-                const encodedUser = encodeURIComponent(JSON.stringify(minimalUser));
-                const encodedInstallations = encodeURIComponent(JSON.stringify(minimalInstallations));
-                const ideLink = `${extAuth.ide}://devasign.devasign/auth?user=${encodedUser}&installations=${encodedInstallations}`;
-                
-                localStorage.removeItem("extensionAuth");
-                localStorage.setItem("ideLink", ideLink);
-                router.push(ROUTES.EXTENSION_SUCCESS);
-                return true;
-            } catch {
+        try {
+            const extAuth = JSON.parse(extensionAuthStr);
+
+            const refreshToken = auth.currentUser?.refreshToken;
+            if (!refreshToken) {
                 return false;
             }
+
+            const ideLink = `${extAuth.ide}://devasign.devasign/auth?refreshToken=${encodeURIComponent(refreshToken)}`;
+
+            localStorage.removeItem("extensionAuth");
+            localStorage.setItem("ideLink", ideLink);
+            router.push(ROUTES.EXTENSION_SUCCESS);
+            return true;
+        } catch {
+            return false;
         }
-        return false;
     };
 
     /**

--- a/apps/project-maintainer/app/(pages)/authenticate/account/page.tsx
+++ b/apps/project-maintainer/app/(pages)/authenticate/account/page.tsx
@@ -3,14 +3,18 @@ import ButtonPrimary from "@devasign/shared/components/ButtonPrimary";
 import { ROUTES } from "@/app/utils/data";
 import { FaGithub } from "react-icons/fa";
 import { UserAPI } from "@/app/services/user.service";
-import { useLockFn, useRequest } from "ahooks";
+import { useAsyncEffect, useLockFn, useRequest } from "ahooks";
 import { toast } from "react-toastify";
 import { ErrorResponse } from "@devasign/shared/models/_global";
 import useUserStore from "@/app/state-management/useUserStore";
-import { auth, getCurrentUser, githubProvider, useAuthenticatedUserCheck } from "@/lib/firebase";
+import { auth, getCurrentUser, githubProvider } from "@/lib/firebase";
 import { signInWithPopup, getAdditionalUserInfo } from "@firebase/auth";
 import { handleApiErrorResponse, handleApiSuccessResponse } from "@/app/utils/helper";
 import { useCustomSearchParams } from "@devasign/shared/hooks";
+import { InstallationAPI } from "@/app/services/installation.service";
+import { UserDto } from "@/app/models/user.model";
+import { useRouter } from "next/navigation";
+import useInstallationStore from "@/app/state-management/useInstallationStore";
 
 /**
  * Authentication page for project maintainers.
@@ -28,16 +32,105 @@ import { useCustomSearchParams } from "@devasign/shared/hooks";
  */
 
 const Account = () => {
-    const router = useAuthenticatedUserCheck();
+    const router = useRouter();
     const { searchParams } = useCustomSearchParams();
     const installationId = searchParams.get("installation_id");
-    const { setCurrentUser } = useUserStore();
+    const { currentUser, setCurrentUser } = useUserStore();
+    const { installationList } = useInstallationStore();
 
-    /** If the user arrived via the GitHub App install callback, forward them to save the installation. */
+    useAsyncEffect(async () => {
+        const user = await getCurrentUser();
+        const source = searchParams.get("source");
+        const ide = searchParams.get("ide");
+        const shouldRedirectToExtension = source === "extension" && ide;
+        let toastId;
+
+        if (shouldRedirectToExtension) {
+            localStorage.setItem("extensionAuth", JSON.stringify({ source, ide }));
+
+            if (user) toastId = toast.loading("Authenticating...");
+        }
+
+        if (!user || !currentUser) {
+            if (toastId) toast.dismiss(toastId);
+            return;
+        }
+
+        // If the user has already connected their GitHub account and has active installations, 
+        // check if they came from the extension to redirect them back, otherwise route to the tasks dashboard.
+        if ((currentUser?._count && currentUser._count.installations > 0) || installationList.length > 0) {
+            if (shouldRedirectToExtension) {
+                const redirected = await handleExtensionRedirect(currentUser!);
+
+                if (!redirected) {
+                    toast.update(toastId!, {
+                        render: "Authentication unsuccessful!",
+                        autoClose: 1000,
+                        type: "error",
+                        isLoading: false
+                    });
+                    router.push(ROUTES.TASKS);
+                    return;
+                }
+
+                toast.update(toastId!, {
+                    render: "Authentication successful!",
+                    autoClose: 1000,
+                    type: "info",
+                    isLoading: false
+                });
+                return;
+            }
+            router.push(ROUTES.TASKS);
+        } else {
+            router.push(ROUTES.ONBOARDING);
+        }
+    }, [searchParams, currentUser]);
+
+    /** 
+     * If the user arrived via the GitHub App install callback, forward them to save the installation. 
+     */
     const getInstallation = () => {
         if (installationId) {
             router.push(`${ROUTES.INSTALLATION.CREATE}?installation_id=${installationId}`);
         }
+    };
+
+    /**
+     * Handles the redirect to the extension after authentication.
+     */
+    const handleExtensionRedirect = async (userObj: UserDto) => {
+        const extensionAuthStr = localStorage.getItem("extensionAuth");
+        if (extensionAuthStr) {
+            try {
+                const extAuth = JSON.parse(extensionAuthStr);
+                const installationsRes = await InstallationAPI.getInstallations({ getRepositories: "true" });
+                const installations = installationsRes.data;
+
+                // Done to avoid hitting the URL maximum length limit
+                const minimalUser = {
+                    i: userObj.userId,
+                    u: userObj.username,
+                    e: userObj.email
+                };
+                const minimalInstallations = installations.map((inst) => ({
+                    i: inst.id,
+                    r: (inst.repositories || []).map((repo) => repo.name)
+                }));
+
+                const encodedUser = encodeURIComponent(JSON.stringify(minimalUser));
+                const encodedInstallations = encodeURIComponent(JSON.stringify(minimalInstallations));
+                const ideLink = `${extAuth.ide}://devasign.devasign/auth?user=${encodedUser}&installations=${encodedInstallations}`;
+
+                localStorage.removeItem("extensionAuth");
+                localStorage.setItem("ideLink", ideLink);
+                router.push(ROUTES.EXTENSION_SUCCESS);
+                return true;
+            } catch {
+                return false;
+            }
+        }
+        return false;
     };
 
     /**
@@ -92,7 +185,10 @@ const Account = () => {
 
                 // Route based on whether the user has connected any repositories
                 if (response.data._count && response.data._count.installations > 0) {
-                    router.push(ROUTES.TASKS);
+                    const redirected = await handleExtensionRedirect(response.data);
+                    if (!redirected) {
+                        router.push(ROUTES.TASKS);
+                    }
                     return;
                 }
                 router.push(ROUTES.ONBOARDING);

--- a/apps/project-maintainer/app/(pages)/authenticate/account/page.tsx
+++ b/apps/project-maintainer/app/(pages)/authenticate/account/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 import { useState } from "react";
 import ButtonPrimary from "@devasign/shared/components/ButtonPrimary";
-import { ROUTES } from "@/app/utils/data";
+import { ALLOWED_IDES, ROUTES } from "@/app/utils/data";
 import { FaGithub } from "react-icons/fa";
 import { UserAPI } from "@/app/services/user.service";
 import { useAsyncEffect, useLockFn, useRequest } from "ahooks";
@@ -110,6 +110,12 @@ const Account = () => {
 
         try {
             const extAuth = JSON.parse(extensionAuthStr);
+
+            // Allowlist of supported IDE URL schemes to prevent arbitrary-scheme injection.
+            if (typeof extAuth?.ide !== "string" || !ALLOWED_IDES.includes(extAuth.ide)) {
+                localStorage.removeItem("extensionAuth");
+                return false;
+            }
 
             const refreshToken = auth.currentUser?.refreshToken;
             if (!refreshToken) {

--- a/apps/project-maintainer/app/(pages)/authenticate/account/page.tsx
+++ b/apps/project-maintainer/app/(pages)/authenticate/account/page.tsx
@@ -43,19 +43,17 @@ const Account = () => {
         const source = searchParams.get("source");
         const ide = searchParams.get("ide");
         const shouldRedirectToExtension = source === "extension" && ide;
-        let toastId;
 
         if (shouldRedirectToExtension) {
             localStorage.setItem("extensionAuth", JSON.stringify({ source, ide }));
-
-            if (user) {
-                toastId = toast.loading("Authenticating...");
-                setIsAuthenticatingExtension(true);
-            }
         }
 
         if (!user || !currentUser) {
-            if (toastId) toast.dismiss(toastId);
+            return;
+        }
+
+        if (installationId) {
+            router.push(`${ROUTES.INSTALLATION.CREATE}?installation_id=${installationId}`);
             return;
         }
 
@@ -63,25 +61,27 @@ const Account = () => {
         // check if they came from the extension to redirect them back, otherwise route to the tasks dashboard.
         if ((currentUser?._count && currentUser._count.installations > 0) || installationList.length > 0) {
             if (shouldRedirectToExtension) {
+                setIsAuthenticatingExtension(true);
+                const toastId = toast.loading("Authenticating...");
                 const redirected = await handleExtensionRedirect();
 
                 if (!redirected) {
-                    toast.update(toastId!, {
+                    toast.update(toastId, {
                         render: "Authentication unsuccessful!",
                         autoClose: 1000,
                         type: "error",
                         isLoading: false
                     });
                     router.push(ROUTES.TASKS);
-                    return;
+                } else {
+                    toast.update(toastId, {
+                        render: "Authentication successful!",
+                        autoClose: 1000,
+                        type: "info",
+                        isLoading: false
+                    });
                 }
-
-                toast.update(toastId!, {
-                    render: "Authentication successful!",
-                    autoClose: 1000,
-                    type: "info",
-                    isLoading: false
-                });
+                setIsAuthenticatingExtension(false);
                 return;
             }
             router.push(ROUTES.TASKS);

--- a/apps/project-maintainer/app/(pages)/authenticate/account/page.tsx
+++ b/apps/project-maintainer/app/(pages)/authenticate/account/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+import { useState } from "react";
 import ButtonPrimary from "@devasign/shared/components/ButtonPrimary";
 import { ROUTES } from "@/app/utils/data";
 import { FaGithub } from "react-icons/fa";
@@ -11,8 +12,6 @@ import { auth, getCurrentUser, githubProvider } from "@/lib/firebase";
 import { signInWithPopup, getAdditionalUserInfo } from "@firebase/auth";
 import { handleApiErrorResponse, handleApiSuccessResponse } from "@/app/utils/helper";
 import { useCustomSearchParams } from "@devasign/shared/hooks";
-import { InstallationAPI } from "@/app/services/installation.service";
-import { UserDto } from "@/app/models/user.model";
 import { useRouter } from "next/navigation";
 import useInstallationStore from "@/app/state-management/useInstallationStore";
 
@@ -37,6 +36,7 @@ const Account = () => {
     const installationId = searchParams.get("installation_id");
     const { currentUser, setCurrentUser } = useUserStore();
     const { installationList } = useInstallationStore();
+    const [isAuthenticatingExtension, setIsAuthenticatingExtension] = useState(false);
 
     useAsyncEffect(async () => {
         const user = await getCurrentUser();
@@ -48,7 +48,10 @@ const Account = () => {
         if (shouldRedirectToExtension) {
             localStorage.setItem("extensionAuth", JSON.stringify({ source, ide }));
 
-            if (user) toastId = toast.loading("Authenticating...");
+            if (user) {
+                toastId = toast.loading("Authenticating...");
+                setIsAuthenticatingExtension(true);
+            }
         }
 
         if (!user || !currentUser) {
@@ -60,7 +63,7 @@ const Account = () => {
         // check if they came from the extension to redirect them back, otherwise route to the tasks dashboard.
         if ((currentUser?._count && currentUser._count.installations > 0) || installationList.length > 0) {
             if (shouldRedirectToExtension) {
-                const redirected = await handleExtensionRedirect(currentUser!);
+                const redirected = await handleExtensionRedirect();
 
                 if (!redirected) {
                     toast.update(toastId!, {
@@ -99,38 +102,29 @@ const Account = () => {
     /**
      * Handles the redirect to the extension after authentication.
      */
-    const handleExtensionRedirect = async (userObj: UserDto) => {
+    const handleExtensionRedirect = async () => {
         const extensionAuthStr = localStorage.getItem("extensionAuth");
-        if (extensionAuthStr) {
-            try {
-                const extAuth = JSON.parse(extensionAuthStr);
-                const installationsRes = await InstallationAPI.getInstallations({ getRepositories: "true" });
-                const installations = installationsRes.data;
+        if (!extensionAuthStr) {
+            return false;
+        }
 
-                // Done to avoid hitting the URL maximum length limit
-                const minimalUser = {
-                    i: userObj.userId,
-                    u: userObj.username,
-                    e: userObj.email
-                };
-                const minimalInstallations = installations.map((inst) => ({
-                    i: inst.id,
-                    r: (inst.repositories || []).map((repo) => repo.name)
-                }));
+        try {
+            const extAuth = JSON.parse(extensionAuthStr);
 
-                const encodedUser = encodeURIComponent(JSON.stringify(minimalUser));
-                const encodedInstallations = encodeURIComponent(JSON.stringify(minimalInstallations));
-                const ideLink = `${extAuth.ide}://devasign.devasign/auth?user=${encodedUser}&installations=${encodedInstallations}`;
-
-                localStorage.removeItem("extensionAuth");
-                localStorage.setItem("ideLink", ideLink);
-                router.push(ROUTES.EXTENSION_SUCCESS);
-                return true;
-            } catch {
+            const refreshToken = auth.currentUser?.refreshToken;
+            if (!refreshToken) {
                 return false;
             }
+
+            const ideLink = `${extAuth.ide}://devasign.devasign/auth?refreshToken=${encodeURIComponent(refreshToken)}`;
+
+            localStorage.removeItem("extensionAuth");
+            localStorage.setItem("ideLink", ideLink);
+            router.push(ROUTES.EXTENSION_SUCCESS);
+            return true;
+        } catch {
+            return false;
         }
-        return false;
     };
 
     /**
@@ -185,7 +179,7 @@ const Account = () => {
 
                 // Route based on whether the user has connected any repositories
                 if (response.data._count && response.data._count.installations > 0) {
-                    const redirected = await handleExtensionRedirect(response.data);
+                    const redirected = await handleExtensionRedirect();
                     if (!redirected) {
                         router.push(ROUTES.TASKS);
                     }
@@ -237,12 +231,14 @@ const Account = () => {
                         ? "Saving User..."
                         : fetchingUser
                             ? "Loading User..."
-                            : "Continue with GitHub"
+                            : isAuthenticatingExtension
+                                ? "Authenticating..."
+                                : "Continue with GitHub"
                 }
                 sideItem={<FaGithub />}
                 attributes={{
                     onClick: handleGitHubAuth,
-                    disabled: creatingUser || fetchingUser
+                    disabled: creatingUser || fetchingUser || isAuthenticatingExtension
                 }}
                 extendedClassName="w-[264px]"
             />

--- a/apps/project-maintainer/app/(pages)/authenticate/extension-success/page.tsx
+++ b/apps/project-maintainer/app/(pages)/authenticate/extension-success/page.tsx
@@ -13,6 +13,7 @@ const ExtensionSuccessPage = () => {
         const link = localStorage.getItem("ideLink");
         if (link) {
             setIdeLink(link);
+            localStorage.removeItem("ideLink");
             window.location.href = link;
         } else {
             router.push(ROUTES.ACCOUNT);

--- a/apps/project-maintainer/app/(pages)/authenticate/extension-success/page.tsx
+++ b/apps/project-maintainer/app/(pages)/authenticate/extension-success/page.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import ButtonPrimary from "@devasign/shared/components/ButtonPrimary";
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { ROUTES } from "@/app/utils/data";
+
+const ExtensionSuccessPage = () => {
+    const [ideLink, setIdeLink] = useState("");
+    const router = useRouter();
+
+    useEffect(() => {
+        const link = localStorage.getItem("ideLink");
+        if (link) {
+            setIdeLink(link);
+            window.location.href = link;
+        } else {
+            router.push(ROUTES.ACCOUNT);
+        }
+    }, [router]);
+
+    return (
+        <div className="sm:pt-[105px] pt-[80px]">
+            <h1 className="text-display-large text-light-100">Authentication successful, continue on your IDE</h1>
+            <p className="text-body-medium text-dark-100 sm:pt-[42px] pt-6 sm:pb-10 pb-8">
+                You can safely close this window if your IDE has already opened.
+                Else, click below to open it manually.
+            </p>
+            <ButtonPrimary
+                format="SOLID"
+                text="Open IDE"
+                attributes={{
+                    onClick: () => {
+                        window.location.href = ideLink;
+                    }
+                }}
+                extendedClassName="w-[150px]"
+            />
+        </div>
+    );
+};
+
+export default ExtensionSuccessPage;

--- a/apps/project-maintainer/app/models/installation.model.ts
+++ b/apps/project-maintainer/app/models/installation.model.ts
@@ -1,3 +1,4 @@
+import { RepositoryDto } from "@devasign/shared/models/github.model";
 import { UserInstallationPermissionDto } from "./permission.model";
 import { SubscriptionPlanDto } from "./subscription-plan.model";
 import { TaskDto, TaskSubmission } from "./task.model";
@@ -23,6 +24,7 @@ export type InstallationDto = {
     userInstallationPermissions?: UserInstallationPermissionDto[];
     transactions?: TransactionDto[];
     taskSubmissions?: TaskSubmission[];
+    repositories?: RepositoryDto[];
 }
 
 export type InstallationAccount = {
@@ -58,6 +60,7 @@ export type QueryInstallationDto = {
     page?: string;
     limit?: string;
     sort?: "asc" | "desc";
+    getRepositories?: "true";
 }
 
 export type QueryInstallationIssues = {

--- a/apps/project-maintainer/app/utils/data.ts
+++ b/apps/project-maintainer/app/utils/data.ts
@@ -1,5 +1,6 @@
 export const ROUTES = {
     ACCOUNT: "/authenticate/account",
+    EXTENSION_SUCCESS: "/authenticate/extension-success",
     SUBSCRIPTION_PLAN: "/authenticate/subscription-plan",
     ONBOARDING: "/onboarding",
     OVERVIEW: "/overview",

--- a/apps/project-maintainer/app/utils/data.ts
+++ b/apps/project-maintainer/app/utils/data.ts
@@ -20,3 +20,19 @@ export const ROUTES = {
 export const FEATURE_GATES = {
     REQUIRE_KYC: "require_kyc"
 };
+
+/**
+ * Allowlist of supported IDE URL schemes for the extension auth redirect.
+ * Restricting to known schemes prevents arbitrary-scheme injection from the
+ * `extensionAuth` value stored in localStorage. Includes VS Code and its forks.
+ */
+export const ALLOWED_IDES = [
+    "vscode", // Visual Studio Code
+    "vscode-insiders", // VS Code Insiders
+    "vscodium", // VSCodium (open-source VS Code build)
+    "cursor", // Cursor
+    "windsurf", // Windsurf (Codeium)
+    "antigravity", // Google Antigravity
+    "trae", // Trae (ByteDance)
+    "positron" // Positron (Posit)
+];

--- a/apps/project-maintainer/tsconfig.json
+++ b/apps/project-maintainer/tsconfig.json
@@ -22,6 +22,6 @@
       "@/*": ["./*"]
     }
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts", "../../packages/shared/models/github.model.ts"],
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
   "exclude": ["node_modules", ".next"]
 }


### PR DESCRIPTION
## Summary

This PR implements the authentication redirect flow for the IDE extension, passing Firebase refresh tokens through to the extension on login completion, and adds URL scheme allowlist validation to guard against open redirect attacks.

## Changes

### Features
- **IDE extension redirect flow** added to handle authentication callbacks and install-time linking (`feat(auth)`)

### Refactors
- **Firebase refresh token** is now passed directly to the IDE extension via redirect instead of access tokens, enabling the extension to manage its own token lifecycle (`refactor(auth)`)
- **Shared models removed** from `tsconfig.json` include arrays to clean up project references (`chore(tsconfig)`)

### Bug Fixes
- **IDE URL scheme allowlist validation** added to the auth flow to prevent arbitrary redirect targets — only registered IDE schemes are now accepted (`fix(auth)`)

## Security Note

The URL scheme validation introduced in `fix(auth)` is a security-relevant change. Ensure the allowlist covers all supported IDE clients (e.g. `vscode://`, `jetbrains://`) and that any new IDE integrations go through the same validation path before being shipped.

## Testing

- [ ] Successful auth login redirects back to the IDE extension with a valid Firebase refresh token
- [ ] Redirect is blocked for unrecognized or arbitrary URL schemes
- [ ] Token refresh works correctly from within the IDE using the passed refresh token
- [ ] TypeScript compilation succeeds with shared models removed from `tsconfig` includes